### PR TITLE
GPU RTX 5000番台の対応を追加しました

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -7,4 +7,5 @@ pip install -r requirements.txt
 
 call .venv_cuda/Scripts/activate
 python.exe -m pip install --upgrade pip
+pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
 pip install -r requirements_cuda.txt

--- a/requirements_cuda.txt
+++ b/requirements_cuda.txt
@@ -1,7 +1,5 @@
-torch==2.2.2
---extra-index-url https://download.pytorch.org/whl/cu121
-faster-whisper==1.0.3
-ctranslate2==4.3.1
+faster-whisper==1.1.0
+ctranslate2==4.5.0
 transformers==4.40.2
 pillow == 10.0.0
 PyAudioWPatch == 0.2.12.6


### PR DESCRIPTION
今度のコミットは二つのファイルの直しです。
ひとつはinstall.bat、もうひとつはrequirements_cuda.txt
前にＸ（https://x.com/misya_ai/status/1910276192072323105）で「RTX 5000番台のGPUにはPyTorchが未対応のため、GPUを利用した文字起こし（Whisper）および翻訳（CTranslate2）はご利用いただけません。」と言いました。自分はちょっと調査した後に、こういうページを見ました：https://www.reddit.com/r/pytorch/comments/1isa608/when_will_pytorch_officially_support_cuda_128_of/
[Immediate-Plate-2313](https://www.reddit.com/user/Immediate-Plate-2313/)
•
[1mo ago](https://www.reddit.com/r/pytorch/comments/1isa608/comment/mjcc6kr/)
Yup, here's the Windows build...Update from our NVIDIA team.

To use PyTorch for Windows on NVIDIA 5080, 5090 Blackwell RTX GPUs use the latest nightly builds, or the command below.

pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128

これで、PyTorchのバージョンを調整したらいいです。
でも、ただPyTorchをアープデートすると、こういうエーラが発生します：「Could not locate cudnn_ops_infer64_8.dll. Please make sure it is in your library path!」
それが、今使ってるctranslate2はまだcuDNN 9をサポートしていないです。というわけで、このページ：（
https://qiita.com/keisuke-okb/items/a531c7aaf91025de399d
）によって、「ctranslate2-4.5.0 faster-whisper-1.1.0」はもうcuDNN 9をサポートしていますから、そのバージョンに設定したらいいです。

あと、RTX 5000シリーズのグラボは「CUDA 12.8」を使いますから、それもインストールしないといけないです。

今のテストによると、RTX5090はlarge-v3だっても、ほぼ1～２秒ぐらいに即時音声認識が完成します。結構使いやすいです。

![e722fd3e0bce736f1bfe3ceb02421216](https://github.com/user-attachments/assets/dfadf230-eabb-4387-8f94-fa12be672e66)
![6a92e2b869da1296677746294f9c3c3b](https://github.com/user-attachments/assets/257ec278-e3ef-4fb0-a7cb-f0a9377055a6)
![image](https://github.com/user-attachments/assets/ffa8fe22-fa75-4411-9a99-069fa81c347d)