### PR TITLE
[Update] OpenAI: Support custom API URL and auth key for OpenAI-compatible endpoints.

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -172,6 +172,8 @@ config_page:
         select_gemini_model:
             label: "Select Gemini Model"
 
+        openai_url:
+            label: "OpenAI API URL"
         openai_auth_key:
             label: "OpenAI Auth Key"
         select_openai_model:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -172,6 +172,8 @@ config_page:
         select_gemini_model:
             label: "Gemini モデルを選択"
 
+        openai_url:
+            label: "OpenAI API URL"
         openai_auth_key:
             label: "OpenAI 認証キー"
         select_openai_model:

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -172,6 +172,8 @@ config_page:
         select_gemini_model:
             label:
 
+        openai_url:
+            label: "OpenAI API URL"
         openai_auth_key:
             label:
         select_openai_model:

--- a/locales/zh-Hans.yml
+++ b/locales/zh-Hans.yml
@@ -172,6 +172,8 @@ config_page:
         select_gemini_model:
             label:
 
+        openai_url:
+            label: "OpenAI API 地址"
         openai_auth_key:
             label:
         select_openai_model:

--- a/locales/zh-Hant.yml
+++ b/locales/zh-Hant.yml
@@ -172,6 +172,8 @@ config_page:
         select_gemini_model:
             label:
 
+        openai_url:
+            label: "OpenAI API 位址"
         openai_auth_key:
             label:
         select_openai_model:

--- a/src-python/config.py
+++ b/src-python/config.py
@@ -695,6 +695,7 @@ class Config:
             if isinstance(val, dict) and set(val.keys()) == set(inst.AUTH_KEYS.keys()) else None
         )
     )
+    OPENAI_URL = ManagedProperty('OPENAI_URL', type_=str)
     LMSTUDIO_URL = ManagedProperty('LMSTUDIO_URL', type_=str)
 
     # --- Transcription settings ---
@@ -955,6 +956,7 @@ class Config:
         self._SELECTED_PLAMO_MODEL = None
         self._SELECTED_GEMINI_MODEL = None
         self._SELECTED_OPENAI_MODEL = None
+        self._OPENAI_URL = "https://api.openai.com/v1"
         self._SELECTED_GROQ_MODEL = None
         self._SELECTED_OPENROUTER_MODEL = None
         self._LMSTUDIO_URL = "http://127.0.0.1:1234/v1"

--- a/src-python/controller.py
+++ b/src-python/controller.py
@@ -1815,6 +1815,7 @@ class Controller:
 
             config.OPENAI_URL = data
             auth_key = config.AUTH_KEYS[translator_name]
+            response = {"status":200, "result":config.OPENAI_URL}
 
             if auth_key:
                 result = model.authenticationTranslatorOpenAIAuthKey(
@@ -1835,15 +1836,22 @@ class Controller:
                         config.SELECTABLE_TRANSLATION_ENGINE_STATUS[translator_name] = False
                         config.SELECTED_OPENAI_MODEL = None
                         self.run(200, self.run_mapping["selected_openai_model"], config.SELECTED_OPENAI_MODEL)
+                        response = VRCTError.create_error_response(
+                            ErrorCode.AUTH_OPENAI_FAILED,
+                            data=None
+                        )
                 else:
                     config.SELECTABLE_TRANSLATION_ENGINE_STATUS[translator_name] = False
                     config.SELECTABLE_OPENAI_MODEL_LIST = []
                     config.SELECTED_OPENAI_MODEL = None
                     self.run(200, self.run_mapping["selectable_openai_model_list"], config.SELECTABLE_OPENAI_MODEL_LIST)
                     self.run(200, self.run_mapping["selected_openai_model"], config.SELECTED_OPENAI_MODEL)
+                    response = VRCTError.create_error_response(
+                        ErrorCode.AUTH_OPENAI_FAILED,
+                        data=None
+                    )
 
             self.updateTranslationEngineAndEngineList()
-            response = {"status":200, "result":config.OPENAI_URL}
         except Exception as e:
             errorLogging()
             response = VRCTError.create_exception_error_response(

--- a/src-python/controller.py
+++ b/src-python/controller.py
@@ -1801,13 +1801,67 @@ class Controller:
     def getOpenAIAuthKey(*args, **kwargs) -> dict:
         return {"status":200, "result":config.AUTH_KEYS["OpenAI_API"]}
 
+    @staticmethod
+    def getOpenAIURL(*args, **kwargs) -> dict:
+        return {"status":200, "result":config.OPENAI_URL}
+
+    def setOpenAIURL(self, data, *args, **kwargs) -> dict:
+        printLog("Set OpenAI URL", data)
+        translator_name = "OpenAI_API"
+        try:
+            data = str(data).strip()
+            if len(data) == 0:
+                data = "https://api.openai.com/v1"
+
+            config.OPENAI_URL = data
+            auth_key = config.AUTH_KEYS[translator_name]
+
+            if auth_key:
+                result = model.authenticationTranslatorOpenAIAuthKey(
+                    auth_key=auth_key,
+                    base_url=config.OPENAI_URL,
+                )
+                if result is True:
+                    config.SELECTABLE_TRANSLATION_ENGINE_STATUS[translator_name] = True
+                    config.SELECTABLE_OPENAI_MODEL_LIST = model.getTranslatorOpenAIModelList()
+                    self.run(200, self.run_mapping["selectable_openai_model_list"], config.SELECTABLE_OPENAI_MODEL_LIST)
+                    if config.SELECTABLE_OPENAI_MODEL_LIST:
+                        if config.SELECTED_OPENAI_MODEL not in config.SELECTABLE_OPENAI_MODEL_LIST:
+                            config.SELECTED_OPENAI_MODEL = config.SELECTABLE_OPENAI_MODEL_LIST[0]
+                        model.setTranslatorOpenAIModel(model=config.SELECTED_OPENAI_MODEL)
+                        self.run(200, self.run_mapping["selected_openai_model"], config.SELECTED_OPENAI_MODEL)
+                        model.updateTranslatorOpenAIClient()
+                    else:
+                        config.SELECTABLE_TRANSLATION_ENGINE_STATUS[translator_name] = False
+                        config.SELECTED_OPENAI_MODEL = None
+                        self.run(200, self.run_mapping["selected_openai_model"], config.SELECTED_OPENAI_MODEL)
+                else:
+                    config.SELECTABLE_TRANSLATION_ENGINE_STATUS[translator_name] = False
+                    config.SELECTABLE_OPENAI_MODEL_LIST = []
+                    config.SELECTED_OPENAI_MODEL = None
+                    self.run(200, self.run_mapping["selectable_openai_model_list"], config.SELECTABLE_OPENAI_MODEL_LIST)
+                    self.run(200, self.run_mapping["selected_openai_model"], config.SELECTED_OPENAI_MODEL)
+
+            self.updateTranslationEngineAndEngineList()
+            response = {"status":200, "result":config.OPENAI_URL}
+        except Exception as e:
+            errorLogging()
+            response = VRCTError.create_exception_error_response(
+                e,
+                data=config.OPENAI_URL
+            )
+        return response
+
     def setOpenAIAuthKey(self, data, *args, **kwargs) -> dict:
         printLog("Set OpenAI Auth Key", data)
         translator_name = "OpenAI_API"
         try:
-            data = str(data)
-            if data.startswith("sk-") and len(data) >= 164:
-                result = model.authenticationTranslatorOpenAIAuthKey(auth_key=data)
+            data = str(data).strip()
+            if len(data) >= 1:
+                result = model.authenticationTranslatorOpenAIAuthKey(
+                    auth_key=data,
+                    base_url=config.OPENAI_URL,
+                )
                 if result is True:
                     key = data
                     auth_keys = config.AUTH_KEYS
@@ -1816,13 +1870,19 @@ class Controller:
                     config.SELECTABLE_TRANSLATION_ENGINE_STATUS[translator_name] = True
                     config.SELECTABLE_OPENAI_MODEL_LIST = model.getTranslatorOpenAIModelList()
                     self.run(200, self.run_mapping["selectable_openai_model_list"], config.SELECTABLE_OPENAI_MODEL_LIST)
-                    if config.SELECTED_OPENAI_MODEL not in config.SELECTABLE_OPENAI_MODEL_LIST:
-                        config.SELECTED_OPENAI_MODEL = config.SELECTABLE_OPENAI_MODEL_LIST[0]
-                    model.setTranslatorOpenAIModel(model=config.SELECTED_OPENAI_MODEL)
-                    self.run(200, self.run_mapping["selected_openai_model"], config.SELECTED_OPENAI_MODEL)
-                    model.updateTranslatorOpenAIClient()
-                    self.updateTranslationEngineAndEngineList()
-                    response = {"status":200, "result":config.AUTH_KEYS[translator_name]}
+                    if len(config.SELECTABLE_OPENAI_MODEL_LIST) == 0:
+                        response = VRCTError.create_error_response(
+                            ErrorCode.AUTH_OPENAI_FAILED,
+                            data=None
+                        )
+                    else:
+                        if config.SELECTED_OPENAI_MODEL not in config.SELECTABLE_OPENAI_MODEL_LIST:
+                            config.SELECTED_OPENAI_MODEL = config.SELECTABLE_OPENAI_MODEL_LIST[0]
+                        model.setTranslatorOpenAIModel(model=config.SELECTED_OPENAI_MODEL)
+                        self.run(200, self.run_mapping["selected_openai_model"], config.SELECTED_OPENAI_MODEL)
+                        model.updateTranslatorOpenAIClient()
+                        self.updateTranslationEngineAndEngineList()
+                        response = {"status":200, "result":config.AUTH_KEYS[translator_name]}
                 else:
                     response = VRCTError.create_error_response(
                         ErrorCode.AUTH_OPENAI_FAILED,
@@ -3224,10 +3284,16 @@ class Controller:
                         if config.AUTH_KEYS[engine] is None:
                             status = False
                         else:
-                            if model.authenticationTranslatorOpenAIAuthKey(auth_key=config.AUTH_KEYS[engine]) is True:
+                            if model.authenticationTranslatorOpenAIAuthKey(
+                                auth_key=config.AUTH_KEYS[engine],
+                                base_url=config.OPENAI_URL,
+                            ) is True:
                                 model_list = model.getTranslatorOpenAIModelList()
-                                selected_model = config.SELECTED_OPENAI_MODEL if config.SELECTED_OPENAI_MODEL in model_list else model_list[0]
-                                status = True
+                                if len(model_list) > 0:
+                                    selected_model = config.SELECTED_OPENAI_MODEL if config.SELECTED_OPENAI_MODEL in model_list else model_list[0]
+                                    status = True
+                                else:
+                                    status = False
                             else:
                                 auth_key_invalid = True
                     case "Groq_API":

--- a/src-python/mainloop.py
+++ b/src-python/mainloop.py
@@ -212,6 +212,8 @@ mapping = {
     "/get/data/selectable_openai_model_list": {"status": True, "variable":controller.getOpenAIModelList},
     "/get/data/selected_openai_model": {"status": True, "variable":controller.getOpenAIModel},
     "/set/data/selected_openai_model": {"status": True, "variable":controller.setOpenAIModel},
+    "/get/data/openai_url": {"status": True, "variable":controller.getOpenAIURL},
+    "/set/data/openai_url": {"status": True, "variable":controller.setOpenAIURL},
     "/get/data/openai_auth_key": {"status": True, "variable":controller.getOpenAIAuthKey},
     "/set/data/openai_auth_key": {"status": True, "variable":controller.setOpenAIAuthKey},
     "/delete/data/openai_auth_key": {"status": True, "variable":controller.delOpenAIAuthKey},

--- a/src-python/models/translation/translation_openai.py
+++ b/src-python/models/translation/translation_openai.py
@@ -32,7 +32,7 @@ def _get_available_text_models(api_key: str, base_url: str | None = None) -> lis
 
     for model in res.data:
         model_id = model.id
-        root = getattr(model, "root", "")
+        model_id_lower = model_id.lower()
 
         # 除外対象のキーワード
         exclude_keywords = [
@@ -48,14 +48,12 @@ def _get_available_text_models(api_key: str, base_url: str | None = None) -> lis
         ]
 
         # 除外キーワードが含まれているモデルをスキップ
-        if any(kw in model_id for kw in exclude_keywords):
+        if any(kw in model_id_lower for kw in exclude_keywords):
             continue
 
-        # GPTモデルまたはFine-tune GPTモデルのみ対象
-        if model_id.startswith("gpt-"):
-            allowed_models.append(model_id)
-        elif model_id.startswith("ft:") and root.startswith("gpt-"):
-            allowed_models.append(model_id)
+        # OpenAI互換エンドポイントでは provider 独自モデル名が多いため、
+        # 除外条件に該当しないテキストモデルを許可する。
+        allowed_models.append(model_id)
 
     allowed_models.sort()
     return allowed_models

--- a/src-python/test_endpoints.py
+++ b/src-python/test_endpoints.py
@@ -261,6 +261,12 @@ class TestMainloop():
             case "/set/data/openai_auth_key":
                 data = "OPENAI_DUMMY_KEY"
                 expected_status = [200, 400]
+            case "/set/data/openai_url":
+                data = random.choice([
+                    "https://api.openai.com/v1",
+                    "http://127.0.0.1:1234/v1",
+                    "http://localhost:11434/v1",
+                ])
             case "/set/data/selected_lmstudio_model":
                 self.config_dict["lmstudio_model_list"], _ = self.main.handleRequest("/get/data/selectable_lmstudio_model_list", None)
                 model_list = self.config_dict.get("lmstudio_model_list", [])

--- a/src-ui/logics/configs/config_page_setter/ui_config_setter.js
+++ b/src-ui/logics/configs/config_page_setter/ui_config_setter.js
@@ -290,6 +290,14 @@ export const SETTINGS_ARRAY = [
     // OpenAI
     {
         Category: "Translation",
+        Base_Name: "OpenAIURL",
+        default_value: "https://api.openai.com/v1",
+        ui_template_id: "input",
+        logics_template_id: "get_set",
+        base_endpoint_name: "openai_url",
+    },
+    {
+        Category: "Translation",
         Base_Name: "OpenAIAuthKey",
         default_value: "",
         ui_template_id: "input",

--- a/src-ui/views/app/config_page/setting_section/setting_box/translation/Translation.jsx
+++ b/src-ui/views/app/config_page/setting_section/setting_box/translation/Translation.jsx
@@ -54,6 +54,7 @@ export const Translation = () => {
             <GeminiAuthKey_Box />
             <GeminiModelContainer />
 
+            <OpenAIURL_Box />
             <OpenAIAuthKey_Box />
             <OpenAIModelContainer />
 
@@ -419,6 +420,30 @@ const OpenAIAuthKey_Box = () => {
                 state={currentOpenAIAuthKey.state}
                 onChangeFunction={onChangeFunction}
                 saveFunction={saveFunction}
+                remove_border_bottom={true}
+            />
+        </>
+    );
+};
+const OpenAIURL_Box = () => {
+    const { t } = useI18n();
+    const { currentOpenAIURL, setOpenAIURL } = useTranslation();
+
+    const { variable, onChangeFunction, saveFunction } = useSaveButtonLogic({
+        variable: currentOpenAIURL.data,
+        state: currentOpenAIURL.state,
+        setFunction: setOpenAIURL,
+        deleteFunction: () => setOpenAIURL("https://api.openai.com/v1"),
+    });
+
+    return (
+        <>
+            <EntryWithSaveButtonContainer
+                label={t("config_page.translation.openai_url.label")}
+                variable={variable}
+                saveFunction={saveFunction}
+                onChangeFunction={onChangeFunction}
+                state={currentOpenAIURL.state}
                 remove_border_bottom={true}
             />
         </>


### PR DESCRIPTION
## Summary
This PR addresses [#89](https://github.com/misyaguziya/VRCT/issues/89).

It adds support for configuring a custom OpenAI-compatible base URL, and wires the setting through the app so the custom endpoint can be used during validation, model fetching, and normal OpenAI-related flows.

### Testing
- Configured the custom base URL to use Cloudflare AI Gateway.
- Successfully validated the endpoint and fetched models.
- Verified standard normal flows by testing with the `gpt-5.4-mini` model, ensuring all requests route correctly through the custom endpoint.


### Screenshots
<img width="1720" height="331" alt="image" src="https://github.com/user-attachments/assets/43143c72-a17e-4c9c-b92d-d53b6b33be5e" />
<img width="1720" height="167" alt="image" src="https://github.com/user-attachments/assets/feeb5465-b5da-42af-9760-73737fde7bae" />
<img width="1761" height="692" alt="image" src="https://github.com/user-attachments/assets/603bc684-4808-402c-ad58-f9f5c06c1b0a" />
