### PR TITLE
[Fix] Added slight fix to message main to add inherited user-select to mess…

### DIFF
--- a/src-ui/views/app/main_page/main_section/message_container/log_box/message_container/MessageContainer.module.scss
+++ b/src-ui/views/app/main_page/main_section/message_container/log_box/message_container/MessageContainer.module.scss
@@ -87,6 +87,9 @@
     font-size: 1.4em;
     overflow-wrap: break-word;
     max-width: 100%;
+    // Makes all children selectable under main, but not ruby
+    * { user-select: text; } 
+    rt { user-select: none; }  
 }
 
 .message_second {


### PR DESCRIPTION
## Summary

I noticed that text with ruby over them (i.e. Show Romaji and/or Show Hiragana enabled over Japanese text) could not be selected. I made a slight modification to the SCSS main_message class to allow user-select for all it's children so it can be selected. Disabled selection for the rt element, it's more of a nuisance when copying the original text.

### Testing
* Updated the associated SCSS file and built the application.
* Enabled the Show Romaji and Show Hiragana, then reviewed selection/copy of the text.

### Screenshot
<img width="919" height="192" alt="image" src="https://github.com/user-attachments/assets/33b0f2c8-1fb5-4005-aa0a-f2bd5ca4f359" />


